### PR TITLE
GET /client

### DIFF
--- a/bin/oauth2-server-pg.js
+++ b/bin/oauth2-server-pg.js
@@ -15,6 +15,11 @@ require('yargs')
         describe: 'oauth grant model to use',
         default: './client-credentials'
       })
+      .option('private-routes', {
+        default: false,
+        type: 'boolean',
+        describe: "should admin-routes, e.g., client list endpoint, be installed (don't run this if service is Internet-facing)"
+      })
   }, function (argv) {
     require('../lib/server')(argv)
   })

--- a/lib/install-private-routes.js
+++ b/lib/install-private-routes.js
@@ -1,0 +1,38 @@
+// routes that should only be accessible
+// to internal services.
+var Client = require('./client')
+var Token = require('./token')
+
+module.exports = function (app) {
+  // used by the internal annotations-api to pull a list of
+  // services providing annotations. TODO: this logic will serve the
+  // usecase of npm Enterprise, which will have a small number of
+  // tokens, but we will need to figure out how to approach this
+  // problem differently for the SASS product.
+  app.get('/client', function (req, res) {
+    var tokens = null
+    // the internal micro-service must provide a shared secret.
+    if (req.query.sharedFetchSecret === process.env.SHARED_FETCH_SECRET) {
+      Token.objects.all().then(function (_tokens) {
+        tokens = _tokens
+
+        return Client.objects.filter({
+          'id:in': tokens.map(function (token) {
+            return token.client_id
+          })
+        })
+      }).then(function (clients) {
+        clients.forEach(function (client) {
+          client.tokens = tokens.filter(function (token) {
+            return token.client_id === client.id
+          })
+        })
+
+        res.setHeader('Content-Type', 'application/json')
+        res.send(clients)
+      })
+    } else {
+      res.status(404).send('not found')
+    }
+  })
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,12 +3,15 @@
 var bodyParser = require('body-parser')
 var express = require('express')
 var OAuthServer = require('@npmcorp/express-oauth-server')
+var Client = require('./client')
+var Token = require('./token')
 
 module.exports = function (opts, cb) {
   var app = express()
 
   opts = opts || {}
 
+  // OAuth endpoints.
   app.oauth = new OAuthServer({
     model: require(opts.model || './client-credentials')
   })
@@ -16,11 +19,44 @@ module.exports = function (opts, cb) {
   app.use(bodyParser.urlencoded({extended: false}))
   app.post('/oauth/token', app.oauth.token())
 
+  // used to test OAuth credentials.
   app.get('/ping', app.oauth.authenticate(), function (req, res) {
     if (res.statusCode === 200) {
       res.send('pong')
     } else {
       res.send('unauthorized')
+    }
+  })
+
+  // used by the internal annotations-api to pull a list of
+  // services providing annotations. TODO: this logic will serve the
+  // usecase of npm Enterprise, which will have a small number of
+  // tokens, but we will need to figure out how to approach this
+  // problem differently for the SASS product.
+  app.get('/client', function (req, res) {
+    var tokens = null
+    // the internal micro-service must provide a shared secret.
+    if (req.query.sharedFetchSecret === process.env.SHARED_FETCH_SECRET) {
+      Token.objects.all().then(function (_tokens) {
+        tokens = _tokens
+
+        return Client.objects.filter({
+          'id:in': tokens.map(function (token) {
+            return token.client_id
+          })
+        })
+      }).then(function (clients) {
+        clients.forEach(function (client) {
+          client.tokens = tokens.filter(function (token) {
+            return token.client_id === client.id
+          })
+        })
+
+        res.setHeader('Content-Type', 'application/json')
+        res.send(clients)
+      })
+    } else {
+      res.status(404).send('not found')
     }
   })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,8 +3,7 @@
 var bodyParser = require('body-parser')
 var express = require('express')
 var OAuthServer = require('@npmcorp/express-oauth-server')
-var Client = require('./client')
-var Token = require('./token')
+var InstallPrivateRoutes = require('./install-private-routes')
 
 module.exports = function (opts, cb) {
   var app = express()
@@ -28,37 +27,7 @@ module.exports = function (opts, cb) {
     }
   })
 
-  // used by the internal annotations-api to pull a list of
-  // services providing annotations. TODO: this logic will serve the
-  // usecase of npm Enterprise, which will have a small number of
-  // tokens, but we will need to figure out how to approach this
-  // problem differently for the SASS product.
-  app.get('/client', function (req, res) {
-    var tokens = null
-    // the internal micro-service must provide a shared secret.
-    if (req.query.sharedFetchSecret === process.env.SHARED_FETCH_SECRET) {
-      Token.objects.all().then(function (_tokens) {
-        tokens = _tokens
-
-        return Client.objects.filter({
-          'id:in': tokens.map(function (token) {
-            return token.client_id
-          })
-        })
-      }).then(function (clients) {
-        clients.forEach(function (client) {
-          client.tokens = tokens.filter(function (token) {
-            return token.client_id === client.id
-          })
-        })
-
-        res.setHeader('Content-Type', 'application/json')
-        res.send(clients)
-      })
-    } else {
-      res.status(404).send('not found')
-    }
-  })
+  if (opts.privateRoutes) InstallPrivateRoutes(app)
 
   var server = app.listen(opts.port || 9999, function () {
     console.info('server listening on ', opts.port)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@npmcorp/express-oauth-server": "^1.0.1",
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
+    "lodash": "^4.8.2",
     "moment": "^2.12.0",
     "ormnomnom": "^2.3.0",
     "pg": "^4.5.1",

--- a/test/server.js
+++ b/test/server.js
@@ -14,7 +14,10 @@ describe('OAuth2 Server', function () {
   var server = null
 
   before(function (done) {
-    helper.startServer(9999, function (err, _server) {
+    helper.startServer({
+      port: 9999,
+      privateRoutes: true
+    }, function (err, _server) {
       if (err) return done(err)
       server = _server
       helper.resetDb(done)

--- a/test/server.js
+++ b/test/server.js
@@ -4,6 +4,7 @@ const helper = require('./test-helper')
 const Client = require('../lib/client')
 const Token = require('../lib/token')
 const request = require('request')
+const Promise = require('bluebird')
 
 require('chai').should()
 
@@ -93,6 +94,57 @@ describe('OAuth2 Server', function () {
     })
 
     after(helper.endTransaction)
+  })
+
+  describe('GET /client', function () {
+    before(function (done) {
+      Client.objects.create({
+        name: 'foo security'
+      }).then(function (client) {
+        return Promise.join(
+          Token.objects.create({
+            client: Client.objects.create({name: 'bar security'}),
+            user_email: 'some@email.com'
+          }),
+          // create two tokens associated with the same
+          // client so that we can test an edge-case.
+          Token.objects.create({
+            client: client,
+            user_email: 'another@email.com'
+          }),
+          Token.objects.create({
+            client: client,
+            user_email: 'third@email.com'
+          })
+        )
+      }).then(function () {
+        return done()
+      })
+    })
+
+    it('returns a list of clients if SHARED_FETCH_SECRET is correct', function (done) {
+      process.env.SHARED_FETCH_SECRET = 'foobar'
+      request.get({url: 'http://localhost:9999/client', json: true, qs: {
+        sharedFetchSecret: 'foobar'
+      }}, function (err, res, clients) {
+        if (err) return done(err)
+        clients.length.should.equal(2)
+        clients[0].name.should.equal('foo security')
+        return done()
+      })
+    })
+
+    it('returns a 404 status if SHARED_FETCH_SECRET is incorrect', function (done) {
+      process.env.SHARED_FETCH_SECRET = 'foobar'
+      request.get({url: 'http://localhost:9999/client', json: true, qs: {
+        sharedFetchSecret: 'apple'
+      }}, function (err, res, body) {
+        if (err) return done(err)
+        res.statusCode.should.equal(404)
+        body.should.equal('not found')
+        return done()
+      })
+    })
   })
 
   after(function () {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -53,8 +53,8 @@ function dropTable (conn, name) {
   return deferred.promise
 }
 
-helper.startServer = function (port, cb) {
-  Server({port: port}, cb)
+helper.startServer = function (opts, cb) {
+  Server(opts, cb)
 }
 
 module.exports = helper


### PR DESCRIPTION
adds endpoint for internal micro-services to pull a list of clients. this is necessary for the annotations-api to seed itself with a list of external applications to make requests to.

reviewers: @nexdrew, @chrisdickinson 
