### PR TITLE
server: Provide a default callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ A PostgreSQL OAuth 2.0 Server.
 
 **starting server:**
 
-```sh
-./bin/oauth2-server-pg server --help
+```./bin/oauth2-server-pg.js start --help
 ```
 
 **generating a client:**

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,9 +8,7 @@ module.exports = function (opts, cb) {
   var app = express()
 
   opts = opts || {}
-  if (typeof cb === 'undefined') {
-    cb = (err) => { if (err) throw err }
-  }
+  cb = cb || ((err) => { if (err) throw err })
 
   app.oauth = new OAuthServer({
     model: require(opts.model || './client-credentials')

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,9 @@ module.exports = function (opts, cb) {
   var app = express()
 
   opts = opts || {}
+  if (undefined === cb){
+    cb = (err,ans)=>{if((err!==undefined) && (err !== null)) throw err; return ans;};
+  }
 
   app.oauth = new OAuthServer({
     model: require(opts.model || './client-credentials')

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,8 +8,8 @@ module.exports = function (opts, cb) {
   var app = express()
 
   opts = opts || {}
-  if (undefined === cb){
-    cb = (err,ans)=>{if((err!==undefined) && (err !== null)) throw err; return ans;};
+  if (typeof cb === 'undefined') {
+    cb = (err) => { if (err) throw err }
   }
 
   app.oauth = new OAuthServer({


### PR DESCRIPTION
Hello,

In server, the callback is optional, yet is used.  This adds a default callback.

An alternative would be to check whether cb exists before using it, however if the server makes more use of the cb that check would have to be repeated over and over.  Might not happen, but just in case, this keeps it DRY.

Regards, Max
