### PR TITLE
Only report coverage if tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - "node"
 before_script:
   - psql -c 'create database oauth2_server;' -U postgres
-after_script: npm run coverage
+after_success: npm run coverage


### PR DESCRIPTION
Just noticed that Travis attempts to `npm run coverage` after a failed build/test. This fixes that.
