### PR TITLE
Update PostGIS to 2.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 #
 # docker-machine create --driver virtualbox oauth
 # docker-machine stop oauth
-# VBoxManage modifyvm "oauth2" --natpf1 "tcp-port5432,tcp,,5432,,5432"
+# VBoxManage modifyvm "oauth" --natpf1 "tcp-port5432,tcp,,5432,,5432"
 # docker-machine start oauth
 # docker-compose build
 # docker-compose up -d

--- a/roles/README.md
+++ b/roles/README.md
@@ -8,9 +8,9 @@ across developer machines:
 ```sh
 docker-machine create --driver virtualbox oauth
 docker-machine stop oauth
-VBoxManage modifyvm "oauth2" --natpf1 "tcp-port5432,tcp,,5432,,5432"
+VBoxManage modifyvm "oauth" --natpf1 "tcp-port5432,tcp,,5432,,5432"
 docker-machine start oauth
 docker-compose build
 docker-compose up -d
-psql "dbname=oauth2_server user=postgres host=0.0.0.0 port=5432"
+docker exec -it oauth2serverpg_postgres_1 psql "dbname=oauth2_server user=postgres host=0.0.0.0 port=5432"
 ```

--- a/roles/postgres/Dockerfile
+++ b/roles/postgres/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:9.4
 MAINTAINER Mike Dillon <mike@appropriate.io>
 
 ENV POSTGIS_MAJOR 2.2
-ENV POSTGIS_VERSION 2.2.1+dfsg-2.pgdg80+1
+ENV POSTGIS_VERSION 2.2.2+dfsg-1.pgdg80+1
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Based on https://github.com/appropriate/docker-postgis/commit/5c96c6d093b6a14777b254cc68dc25e3935c8bca. Version 2.2.1 of PostGIS no longer works; upgrade to version 2.2.2.

Also updated commands in docs to work. Note that if you have a different version of Postgres already installed (e.g. 9.5 instead of 9.4), then using native `psql` may not work, but you can exec into the Docker container and use the `psql` bin there.
