### PR TITLE
adds field for "webhook" and "type"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,8 @@ function Client (opts) {
   this.homepage = opts.homepage
   this.description = opts.description
   this.callback = opts.callback
+  this.webhook = opts.webhook
+  this.type = opts.type
   this.created = opts.created
   this.deleted = opts.deleted
 }
@@ -27,6 +29,8 @@ Client.objects = orm(Client, {
   homepage: orm.joi.string(),
   description: orm.joi.string(),
   callback: orm.joi.string(),
+  webhook: orm.joi.string(),
+  type: orm.joi.string(),
   created: orm.joi.date().default(function () {
     return (new Date()).toISOString()
   }, 'date'),

--- a/lib/install-private-routes.js
+++ b/lib/install-private-routes.js
@@ -41,7 +41,9 @@ module.exports = function (app) {
         'name',
         'homepage',
         'description',
-        'callback'
+        'callback',
+        'webhook',
+        'type'
       ])
       Client.objects.create(payload)
         .then((client) => {

--- a/migrations/20160324224401-create-client.js
+++ b/migrations/20160324224401-create-client.js
@@ -12,6 +12,8 @@ exports.up = function (db, callback) {
       email: { type: type.STRING },
       description: { type: type.STRING },
       callback: { type: type.STRING },
+      webhook: { type: type.STRING },
+      type: { type: type.STRING },
       created: { type: type.DATE_TIME },
       deleted: { type: type.DATE_TIME }
     }

--- a/test/server.js
+++ b/test/server.js
@@ -164,7 +164,9 @@ describe('OAuth2 Server', function () {
           name: 'foo-integration',
           homepage: 'http://example.com',
           description: 'my awesome integration',
-          callback: 'http://example.com/callback'
+          callback: 'http://example.com/callback',
+          webhook: 'http://example.com/webhook',
+          type: 'badge plus'
         }
         process.env.SHARED_FETCH_SECRET = 'foobar'
         request.post({
@@ -182,7 +184,9 @@ describe('OAuth2 Server', function () {
             'name',
             'homepage',
             'description',
-            'callback'
+            'callback',
+            'webhook',
+            'type'
           ]).should.deep.equal(payload)
           return done()
         })


### PR DESCRIPTION
- adds a `webhook` field, representing the URL that webhooks should be dispatched to.
- adds a `type` field, representing the type of integration (currently `badge plus` is the only category).
