### PR TITLE
adds a command for installing addons from npm

### DIFF
--- a/bin/oauth2-server-pg.js
+++ b/bin/oauth2-server-pg.js
@@ -8,7 +8,7 @@ require('yargs')
       .option('port', {
         alias: 'p',
         describe: 'port to run server on',
-        default: 9999
+        default: 8084
       })
       .option('model', {
         alias: 'm',
@@ -23,6 +23,7 @@ require('yargs')
   }, function (argv) {
     require('../lib/server')(argv)
   })
+  .command(require('../lib/install'))
   .help()
   .alias('help', 'h')
   .argv

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,7 +7,7 @@ const pg = require('pg')
 orm.setConnection(function () {
   const deferred = Promise.defer()
 
-  var config = require('../config-test')
+  var config = require(process.env.DB_CONFIG ? process.env.DB_CONFIG : '../config-test')
 
   pg.connect(config.connection, function (err, conn, done) {
     if (err) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,0 +1,156 @@
+const _ = require('lodash')
+const request = require('request')
+const Promise = require('bluebird')
+const figures = require('figures')
+const exec = require('child_process').exec
+
+const prefix = 'npm-addon-'
+const resolve = require('url').resolve
+
+exports.command = 'install <addon>'
+exports.describe = 'installs a new OAuth 2.0 client from a package'
+exports.builder = function (yargs) {
+  return yargs
+    .option('registry', {
+      alias: 'r',
+      describe: 'npm registry URL',
+      default: 'https://registry.npmjs.org'
+    })
+    .option('port', {
+      alias: 'p',
+      describe: 'port server is running on',
+      default: 8084
+    })
+}
+
+exports.handler = function (argv) {
+  var addon = prefix + argv.addon
+  var meta = null
+  var client = null
+
+  exists(addon, argv)
+    .then(function () {
+      console.info(figures.tick + ' found addon "' + argv.addon + '"')
+      return install(addon, argv)
+    })
+    .then(function () {
+      console.info(figures.tick + ' installed addon "' + argv.addon + '"')
+      meta = require(addon)
+      return createClient(meta, argv)
+    })
+    .then(function (_client) {
+      client = _client
+      console.info(figures.tick + ' generated client for "' + argv.addon + '"')
+      return createToken(client, argv)
+    })
+    .then(function (token) {
+      console.info(figures.tick + ' generated access token for "' + argv.addon + '"')
+      return sendToken(client, token, argv)
+    })
+    .then(function () {
+      console.info('\\o/ addon "' + argv.addon + '" successfully installed')
+    })
+    .catch(function (err) {
+      console.error(err.message)
+    })
+}
+
+function exists (addon, argv) {
+  const deferred = Promise.defer()
+
+  request.get(resolve(argv.registry, addon), function (err, res) {
+    if (err) return deferred.reject(err)
+    if (res.statusCode >= 400) {
+      var msg = figures.cross + ' could not find addon "' + argv.addon + '" in registry ' + argv.registry
+      return deferred.reject(Error(msg))
+    }
+    return deferred.resolve()
+  })
+
+  return deferred.promise
+}
+
+function install (addon, argv) {
+  const deferred = Promise.defer()
+
+  console.info('running npm install for ' + argv.addon + ' ' + figures.ellipsis)
+  exec('npm install ' + addon + '@latest --registry=' + argv.registry, function (err, stdout, stderr) {
+    var errMessage = null
+    if (err) errMessage = err.message
+    if (stderr) errMessage = stderr
+    if (errMessage) {
+      var msg = figures.cross + ' failed to install ' + argv.addon
+      return deferred.reject(Error(msg))
+    }
+    return deferred.resolve()
+  })
+
+  return deferred.promise
+}
+
+function createClient (meta, argv) {
+  const deferred = Promise.defer()
+
+  request.post({
+    url: 'http://localhost:' + argv.port + '/client',
+    json: true,
+    qs: {
+      sharedFetchSecret: process.env.SHARED_FETCH_SECRET
+    },
+    body: meta
+  }, (err, res, client) => {
+    if (err || res.statusCode >= 400) {
+      var msg = figures.cross + ' failed to generate client for "' + argv.addon + '"'
+      return deferred.reject(Error(msg))
+    }
+    return deferred.resolve(client)
+  })
+
+  return deferred.promise
+}
+
+function createToken (client, argv) {
+  const deferred = Promise.defer()
+
+  request.post({
+    url: 'http://localhost:' + argv.port + '/client/' + client.client_id + '/token',
+    json: true,
+    qs: {
+      sharedFetchSecret: process.env.SHARED_FETCH_SECRET
+    },
+    body: {
+      user_email: process.env.BILLING_EMAIL
+    }
+  }, (err, res, token) => {
+    if (err || res.statusCode >= 400) {
+      var msg = figures.cross + ' failed to generate access token for "' + argv.addon + '"'
+      return deferred.reject(Error(msg))
+    }
+    return deferred.resolve(token)
+  })
+
+  return deferred.promise
+}
+
+function sendToken (client, token, argv) {
+  const deferred = Promise.defer()
+
+  request.post({
+    url: client.callback,
+    json: true,
+    body: _.pick(token, [
+      'refresh_token',
+      'access_token',
+      'refresh_expires',
+      'access_expires'
+    ])
+  }, (err, res, client) => {
+    if (err || res.statusCode >= 400) {
+      var msg = figures.cross + ' failed to deliver access token for "' + argv.addon + '"'
+      return deferred.reject(Error(msg))
+    }
+    return deferred.resolve(client)
+  })
+
+  return deferred.promise
+}

--- a/lib/install.js
+++ b/lib/install.js
@@ -138,12 +138,17 @@ function sendToken (client, token, argv) {
   request.post({
     url: client.callback,
     json: true,
-    body: _.pick(token, [
-      'refresh_token',
-      'access_token',
-      'refresh_expires',
-      'access_expires'
-    ])
+    body: _.extend(
+      {
+        email: process.env.BILLING_EMAIL
+      },
+      _.pick(token, [
+        'refresh_token',
+        'access_token',
+        'refresh_expires',
+        'access_expires'
+      ])
+    )
   }, (err, res, client) => {
     if (err || res.statusCode >= 400) {
       var msg = figures.cross + ' failed to deliver access token for "' + argv.addon + '"'

--- a/lib/server.js
+++ b/lib/server.js
@@ -30,7 +30,7 @@ module.exports = function (opts, cb) {
 
   if (opts.privateRoutes) InstallPrivateRoutes(app)
 
-  var server = app.listen(opts.port || 9999, function () {
+  var server = app.listen(opts.port || 8084, function () {
     console.info('server listening on ', opts.port)
     return cb(null, server)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-server-pg",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "PostgreSQL and Express powered OAuth 2.0 server",
   "main": "./lib/server.js",
   "bin": "./bin/oauth2-server-pg.js",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@npmcorp/express-oauth-server": "^1.0.1",
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
+    "figures": "^1.5.0",
     "lodash": "^4.8.2",
     "moment": "^2.12.0",
     "ormnomnom": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,21 +29,21 @@
     "@npmcorp/express-oauth-server": "^1.0.1",
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
+    "db-migrate": "^0.9.23",
     "figures": "^1.5.0",
     "lodash": "^4.8.2",
     "moment": "^2.12.0",
     "ormnomnom": "^2.3.0",
     "pg": "^4.5.1",
+    "request": "^2.69.0",
     "uuid": "^2.0.1",
     "yargs": "^4.3.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.8",
-    "db-migrate": "^0.9.23",
     "mocha": "^2.4.5",
     "nyc": "^6.1.1",
-    "request": "^2.69.0",
     "simple-oauth2": "^0.5.1",
     "standard": "^6.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "pretest": "standard",
     "test": "nyc mocha --timeout=5000 test/*.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "migrate": "db-migrate --config=./config-test.json --env=connection"
+    "migrate-test": "db-migrate --config=./config-test.json --env=connection",
+    "migrate": "db-migrate --config=./config.json --env=connection"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-server-pg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PostgreSQL and Express powered OAuth 2.0 server",
   "main": "./lib/server.js",
   "bin": "./bin/oauth2-server-pg.js",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
     "db-migrate": "^0.9.23",
+    "express": "^4.13.4",
     "figures": "^1.5.0",
     "lodash": "^4.8.2",
     "moment": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-server-pg",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PostgreSQL and Express powered OAuth 2.0 server",
   "main": "./lib/server.js",
   "bin": "./bin/oauth2-server-pg.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-server-pg",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "PostgreSQL and Express powered OAuth 2.0 server",
   "main": "./lib/server.js",
   "bin": "./bin/oauth2-server-pg.js",

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -34,7 +34,7 @@ helper.resetDb = function (cb) {
     })
     .done(function () {
       // repopulate the schema.
-      exec('npm run-script migrate -- up', function (e, stdout, stderr) {
+      exec('npm run-script migrate-test -- up', function (e, stdout, stderr) {
         done() // return the PG resource.
         return cb() // return to tests.
       })


### PR DESCRIPTION
When you run `oauth2-server-pg install <addon>` it:
- fetches the addon, which has been published to npm.
- use the meta-information published with the addon to populate the clients table in the oauth database.

I'm a terrible person and should write more tests for this; my plan is to loop around and add more tests once we have some end-to-end integration testing done.
