### PR TITLE
feat: install addon from URL rather than npm module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 services:
   - postgres
 node_js:
-  - "node"
+  - "5"
 before_script:
   - psql -c 'create database oauth2_server;' -U postgres
 after_success: npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.4.0"></a>
+# [1.4.0](https://github.com/npm/oauth2-server-pg/compare/v1.2.0...v1.4.0) (2016-05-06)
+
+
+### Features
+
+* allow an integration provider to specify a post-install hook ([#15](https://github.com/npm/oauth2-server-pg/issues/15)) ([e509cfb](https://github.com/npm/oauth2-server-pg/commit/e509cfb))
+* you can now remove a client once it is added ([#13](https://github.com/npm/oauth2-server-pg/issues/13)) ([d81ac92](https://github.com/npm/oauth2-server-pg/commit/d81ac92))
+
+
+
 <a name="1.3.0"></a>
 # [1.3.0](https://github.com/npm/oauth2-server-pg/compare/v1.2.0...v1.3.0) (2016-05-06)
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -39,7 +39,8 @@ exports.handler = function (argv) {
         return npmInstall(addon, argv)
       }
     })
-    .then(function (meta) {
+    .then(function (_meta) {
+      meta = _meta
       console.info(figures.tick + ' installed addon "' + argv.addon + '"')
       return createClient(meta, argv)
     })

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,8 +1,10 @@
 const _ = require('lodash')
+const isUrl = require('is-url')
 const request = require('request')
 const Promise = require('bluebird')
 const figures = require('figures')
 const npmInstall = require('./util').npmInstall
+const getMeta = require('./util').getMeta
 const exists = require('./util').exists
 
 const prefix = 'npm-addon-'
@@ -31,11 +33,14 @@ exports.handler = function (argv) {
   exists(addon, argv)
     .then(function () {
       console.info(figures.tick + ' found addon "' + argv.addon + '"')
-      return npmInstall(addon, argv)
+      if (isUrl(argv.addon)) {
+        return getMeta(argv.addon, argv)
+      } else {
+        return npmInstall(addon, argv)
+      }
     })
-    .then(function () {
+    .then(function (meta) {
       console.info(figures.tick + ' installed addon "' + argv.addon + '"')
-      meta = require(addon)
       return createClient(meta, argv)
     })
     .then(function (_client) {

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -26,7 +26,6 @@ exports.builder = function (yargs) {
 
 exports.handler = function (argv) {
   var addon = prefix + argv.addon
-  var meta = null
 
   exists(addon, argv)
     .then(function () {
@@ -38,7 +37,6 @@ exports.handler = function (argv) {
       }
     })
     .then(function (meta) {
-      console.log(meta)
       console.info(figures.tick + ' installed addon for "' + argv.addon + '"')
       return deleteClient(meta, argv)
     })

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,7 +1,9 @@
+const isUrl = require('is-url')
 const request = require('request')
 const Promise = require('bluebird')
 const figures = require('figures')
 const npmInstall = require('./util').npmInstall
+const getMeta = require('./util').getMeta
 const exists = require('./util').exists
 
 const prefix = 'npm-addon-'
@@ -29,11 +31,15 @@ exports.handler = function (argv) {
   exists(addon, argv)
     .then(function () {
       console.info(figures.tick + ' found addon "' + argv.addon + '"')
-      return npmInstall(addon, argv)
+      if (isUrl(argv.addon)) {
+        return getMeta(argv.addon, argv)
+      } else {
+        return npmInstall(addon, argv)
+      }
     })
-    .then(function () {
+    .then(function (meta) {
+      console.log(meta)
       console.info(figures.tick + ' installed addon for "' + argv.addon + '"')
-      meta = require(addon)
       return deleteClient(meta, argv)
     })
     .then(function () {

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const figures = require('figures')
 const Promise = require('bluebird')
 const request = require('request')
 const resolve = require('url').resolve
+const isUrl = require('is-url')
 
 module.exports = {
   // npm install a module from an npm module.
@@ -18,21 +19,43 @@ module.exports = {
         var msg = figures.cross + ' failed to install ' + argv.addon
         return deferred.reject(Error(msg))
       }
-      return deferred.resolve()
+
+      return deferred.resolve(require(addon))
     })
 
     return deferred.promise
   },
   exists (addon, argv) {
     const deferred = Promise.defer()
+    var url = argv.addon
+    if (!isUrl(url)) {
+      url = resolve(argv.registry, addon)
+    }
 
-    request.get(resolve(argv.registry, addon), function (err, res) {
+    request.get(url, function (err, res) {
       if (err) return deferred.reject(err)
       if (res.statusCode >= 400) {
         var msg = figures.cross + ' could not find addon "' + argv.addon + '" in registry ' + argv.registry
         return deferred.reject(Error(msg))
       }
       return deferred.resolve()
+    })
+
+    return deferred.promise
+  },
+  getMeta (url, argv) {
+    const deferred = Promise.defer()
+
+    request.get({
+      url: url,
+      json: true
+    }, function (err, res, meta) {
+      if (err) return deferred.reject(err)
+      if (res.statusCode >= 400) {
+        var msg = figures.cross + ' could not find addon "' + argv.addon + '" in registry ' + argv.registry
+        return deferred.reject(Error(msg))
+      }
+      return deferred.resolve(meta)
     })
 
     return deferred.promise

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db-migrate": "^0.9.23",
     "express": "^4.13.4",
     "figures": "^1.5.0",
+    "is-url": "^1.2.1",
     "lodash": "^4.8.2",
     "moment": "^2.12.0",
     "ormnomnom": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-server-pg",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PostgreSQL and Express powered OAuth 2.0 server",
   "main": "./lib/server.js",
   "bin": "./bin/oauth2-server-pg.js",


### PR DESCRIPTION
1. this makes it easier for other on-prem products to integrate with npm Enteprise (since they can generate meta-information specific to their addon).
2. I received feedback that forcing people to publish a module for their addon feels weird.
3. It cuts off the discussion about what scopes should be used for addons at the pass.
